### PR TITLE
feat: add podAnnotations and labels configuration options

### DIFF
--- a/charts/registry-creds/Chart.yaml
+++ b/charts/registry-creds/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.9"
 description: A Helm chart for registry creds
 name: registry-creds
-version: 1.0.1
+version: 1.1.0
 home: https://hub.docker.com/r/upmcenterprises/registry-creds
 sources:
   - https://github.com/upmc-enterprises/registry-creds

--- a/charts/registry-creds/README.md
+++ b/charts/registry-creds/README.md
@@ -130,6 +130,8 @@ Parameter | Description | Default
 `image.pullPolicy` | container image pull policy | `"IfNotPresent"`
 `nameOverride` | override name of app |`""`
 `fullnameOverride` | override full name of app | `""`
+`podLabels` | labels to be added to pods | `{}`
+`podAnnotations` | annotations to be added to pods | `{}`
 `dpr.enabled` | enable the injection of docker private registry credentials | `false`
 `dpr.existingSecretName` | defines an existing secret (in kube-system namespace) containing the credentials| `""`
 `dpr.user` | user for authenticating with docker private registry. Only applicable if dpr.existingSecretName is empty | `""`

--- a/charts/registry-creds/templates/deployment.yaml
+++ b/charts/registry-creds/templates/deployment.yaml
@@ -19,6 +19,17 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "registry-creds.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- if .Values.podLabels }}
+      {{- range $key, $value := .Values.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+      {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
     spec:
       {{- if and .Values.rbac.enabled }}
       serviceAccountName: {{ default (include  "registry-creds.name" .) .Values.rbac.existingServiceAccountName }}

--- a/charts/registry-creds/values.yaml
+++ b/charts/registry-creds/values.yaml
@@ -7,6 +7,8 @@ image:
 
 nameOverride: ""
 fullnameOverride: ""
+podLabels: {}
+podAnnotations: {}
 
 dpr:
   # dpr.enabled enables the injection of docker private registry credentials


### PR DESCRIPTION
This PR add support to change annotations and labels for the deployed pods. It effectively add `podAnnotations` and `podLabels` as a base value of values.yaml.
This is useful when using services like [kube2iam](https://github.com/jtblin/kube2iam) which requires to change the pod annotations in order to allow the specified pod to use a specific AWS role.

#### Example
*values.yaml*
```
podAnnotations:
  test: test
podLabels:
  test: test
[...]
```

*Relevant `kubectl get pod` metada part*
```
[...]
metadata:
  annotations:
    [...]
    test: test
  [...]
  labels:
    [...]
    test: test
[....]
```

