### PR TITLE
Optional values

### DIFF
--- a/charts/registry-creds/Chart.yaml
+++ b/charts/registry-creds/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.9"
 description: A Helm chart for registry creds
 name: registry-creds
-version: 1.1.0
+version: 1.1.1
 home: https://hub.docker.com/r/upmcenterprises/registry-creds
 sources:
   - https://github.com/upmc-enterprises/registry-creds

--- a/charts/registry-creds/templates/deployment.yaml
+++ b/charts/registry-creds/templates/deployment.yaml
@@ -57,16 +57,20 @@ spec:
                 secretKeyRef:
                   name: {{ default (include "registry-creds.name" . | printf "%s-ecr") .Values.ecr.existingSecretName }}
                   key: aws-account
+            {{- if .Values.ecr.awsRegion }}
             - name: awsregion
               valueFrom:
                 secretKeyRef:
                   name: {{ default (include "registry-creds.name" . | printf "%s-ecr") .Values.ecr.existingSecretName }}
                   key: aws-region
+            {{- end }}
+            {{- if .Values.ecr.awsAssumeRole }}
             - name: aws_assume_role
               valueFrom:
                 secretKeyRef:
                   name: {{ default (include "registry-creds.name" . | printf "%s-ecr") .Values.ecr.existingSecretName }}
                   key: aws-assume-role
+            {{- end }}
             {{- end }}
             {{- if .Values.dpr.enabled }}
             - name: DOCKER_PRIVATE_REGISTRY_PASSWORD


### PR DESCRIPTION
This PR make sure that `awsRegion` and `awsAssumeRole` are really optional.

Right now, `awsRegion` and `awsAssumeRole` are always set in the deployment objects however, the documentation of [upmc-enterprises](https://github.com/upmc-enterprises/registry-creds#parameters) states this :
```
awsregion: (optional) Can override the default AWS region by setting this variable.
aws-assume-role (optional) can provide a role ARN that will be assumed for getting ECR authorization tokens
```
Those two arguments are optional. This patch correct this behavior.