### PR TITLE
Allow aws-assume-role to be left empty.

### DIFF
--- a/charts/registry-creds/Chart.yaml
+++ b/charts/registry-creds/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.9"
 description: A Helm chart for registry creds
 name: registry-creds
-version: 1.1.1
+version: 1.1.2
 home: https://hub.docker.com/r/upmcenterprises/registry-creds
 sources:
   - https://github.com/upmc-enterprises/registry-creds

--- a/charts/registry-creds/templates/secrets_ecr.yaml
+++ b/charts/registry-creds/templates/secrets_ecr.yaml
@@ -8,11 +8,11 @@ metadata:
         app: registry-creds
         cloud: ecr
 data:
-    AWS_ACCESS_KEY_ID: {{ .Values.ecr.awsAccessKeyId | b64enc }}
-    AWS_SECRET_ACCESS_KEY: {{ .Values.ecr.awsSecretAccessKey | b64enc }}
+    AWS_ACCESS_KEY_ID: {{ .Values.ecr.awsAccessKeyId | b64enc | quote }}
+    AWS_SECRET_ACCESS_KEY: {{ .Values.ecr.awsSecretAccessKey | b64enc | quote }}
     AWS_SESSION_TOKEN: ""
-    aws-account: {{ .Values.ecr.awsAccount | b64enc }}
-    aws-region: {{ .Values.ecr.awsRegion | b64enc }}
-    aws-assume-role: {{ .Values.ecr.awsAssumeRole | b64enc }}
+    aws-account: {{ .Values.ecr.awsAccount | b64enc | quote }}
+    aws-region: {{ .Values.ecr.awsRegion | b64enc | quote }}
+    aws-assume-role: {{ .Values.ecr.awsAssumeRole | b64enc | quote }}
 type: Opaque
 {{- end }}


### PR DESCRIPTION
Without this change, assume-role seems to be required and the install fails with the following error.

```
Error: UPGRADE FAILED: error validating "": error validating data: unknown object type "nil" in Secret.data.aws-assume-role
```