### PR TITLE
Upgrade registry creds to v1.10

### DIFF
--- a/charts/registry-creds/Chart.yaml
+++ b/charts/registry-creds/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.9"
 description: A Helm chart for registry creds
 name: registry-creds
-version: 1.1.3
+version: 1.2.0
 home: https://hub.docker.com/r/upmcenterprises/registry-creds
 sources:
   - https://github.com/upmc-enterprises/registry-creds

--- a/charts/registry-creds/README.md
+++ b/charts/registry-creds/README.md
@@ -148,6 +148,11 @@ Parameter | Description | Default
 `gcr.existingSecretName` | defines an existing secret (in kube-system namespace) containing the credentials| `""`
 `gcr.applicationDefaultCredentialsJson` | JSON representing google cloud credentials. Only applicable if gcr.existingSecretName is empty | `""`
 `gcr.url` | URL for google container registry. Only applicable if gcr.existingSecretName is empty | `"https://gcr.io"`
+`acr.enabled` | enables the injection of azure container registry credentials | `false`
+`acr.existingSecretName` | defines an existing secret (in kube-system namespace) containing the credentials| `""`
+`acr.url` | defines the url of azure container registry| Only applicable if acr.existingSecretName is empty | `""`
+`acr.clientId` | is the client id used to access azure container registry | Only applicable if acr.existingSecretName is empty | `""`
+`acr.password` | is the client password used to access azure container registry | Only applicable if acr.existingSecretName is empty | `""`
 `rbac.enabled` | enables the usage of RBAC for registry-creds (needed for clusters with RBAC enabled) | `true`
 `rbac.existingServiceAccountName` | name of an existing service account to be used for RBAC permissions. If not defined a new service account will be created by the chart | `""`
 `resources.limits`.memory | memory resource limit | `"100Mi"`

--- a/charts/registry-creds/README.md
+++ b/charts/registry-creds/README.md
@@ -47,7 +47,7 @@ helm install --name registry-creds --set dpr.enabled=true --set-string dpr.user=
 
 #### From AWS
 
-Ensure your EC2 instances have the appropriate permissions as described in 
+Ensure your EC2 instances have the appropriate permissions as described in
 [registry-creds](https://github.com/upmc-enterprises/registry-creds) documentation.
 
 ```console
@@ -69,7 +69,7 @@ Create a `custom-values.yaml` file:
 
 ```yaml
 gcr:
-  enabled: false  
+  enabled: false
   applicationDefaultCredentialsJson: |
   {
     "client_id": "myID",

--- a/charts/registry-creds/templates/NOTES.txt
+++ b/charts/registry-creds/templates/NOTES.txt
@@ -3,4 +3,4 @@ registry-creds is now installed on your Kubernetes cluster
 If everything is ok, you should see one or more secrets (depending on the enabled types) created on every existing
 namespace (except for kube-system):
 
-kubectl get secret | egrep "(dpr|ecr|gcr)-secret"
+kubectl get secret | egrep "(dpr|ecr|gcr|acr)-secret"

--- a/charts/registry-creds/templates/deployment.yaml
+++ b/charts/registry-creds/templates/deployment.yaml
@@ -89,6 +89,23 @@ spec:
                   name: {{ default (include "registry-creds.name" . | printf "%s-dpr") .Values.dpr.existingSecretName }}
                   key: DOCKER_PRIVATE_REGISTRY_USER
             {{- end }}
+            {{- if .Values.acr.enabled }}
+            - name: ACR_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "registry-creds.name" . | printf "%s-acr") .Values.acr.existingSecretName }}
+                  key: ACR_URL
+            - name: ACR_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "registry-creds.name" . | printf "%s-acr") .Values.acr.existingSecretName }}
+                  key: ACR_CLIENT_ID
+            - name: ACR_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "registry-creds.name" . | printf "%s-acr") .Values.acr.existingSecretName }}
+                  key: ACR_PASSWORD
+            {{- end }}
           {{- if .Values.gcr.enabled }}
           volumeMounts:
             - name: {{ template "registry-creds.name" . }}-gcr

--- a/charts/registry-creds/templates/rbac.yaml
+++ b/charts/registry-creds/templates/rbac.yaml
@@ -27,7 +27,7 @@ rules:
           - get
           - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
     name: {{ template "registry-creds.name" . }}

--- a/charts/registry-creds/templates/secrets_acr.yaml
+++ b/charts/registry-creds/templates/secrets_acr.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.acr.enabled (not .Values.acr.existingSecretName) }}
+apiVersion: v1
+kind: Secret
+metadata:
+    name: {{ template "registry-creds.name" . }}-acr
+    namespace: kube-system
+    labels:
+        app: registry-creds
+        cloud: acr
+data:
+    ACR_URL: {{ .Values.acr.url | b64enc | quote }}
+    ACR_CLIENT_ID: {{ .Values.acr.clientId | b64enc | quote }}
+    ACR_PASSWORD: {{ .Values.acr.password | b64enc | quote }}
+type: Opaque
+{{- end }}

--- a/charts/registry-creds/values.yaml
+++ b/charts/registry-creds/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   name: "upmcenterprises/registry-creds"
-  tag: "1.9"
+  tag: "1.10"
   pullPolicy: "IfNotPresent"
 
 nameOverride: ""
@@ -50,6 +50,18 @@ gcr:
   applicationDefaultCredentialsJson: ""
   # gcr.url is the URL for google container registry. Only applicable if gcr.existingSecretName is empty
   url: "https://gcr.io"
+
+acr:
+  # acr.enabled enables the injection of azure container registry credentials
+  enabled: false
+  # acr.existingSecretName defines an existing secret (in kube-system namespace) containing the credentials
+  existingSecretName: ""
+  # acr.url defines the url of azure container registry. Only applicable if acr.existingSecretName is empty
+  url: ""
+  # acr.clientId is the client id used to access azure container registry. Only applicable if acr.existingSecretName is empty
+  clientId: ""
+  # acr.password is the client password used to access azure container registry. Only applicable if acr.existingSecretName is empty
+  password: ""
 
 rbac:
   # rbac.enabled enables the usage of RBAC for registry-creds


### PR DESCRIPTION
I upgraded this Helm chart with latest registry-creds docker image (v1.10) and updated the api version for `ClusterRoleBinding` resource.

Please help to check this PR. Thanks a lot.