### PR TITLE
feat: Allow adding environment variables

### DIFF
--- a/charts/registry-creds/Chart.yaml
+++ b/charts/registry-creds/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.10"
 description: A Helm chart for registry creds
 name: registry-creds
-version: 1.2.2
+version: 1.3.0
 home: https://hub.docker.com/r/upmcenterprises/registry-creds
 sources:
   - https://github.com/upmc-enterprises/registry-creds

--- a/charts/registry-creds/templates/deployment.yaml
+++ b/charts/registry-creds/templates/deployment.yaml
@@ -106,6 +106,10 @@ spec:
                   name: {{ default (include "registry-creds.name" . | printf "%s-acr") .Values.acr.existingSecretName }}
                   key: ACR_PASSWORD
             {{- end }}
+            {{- range $key, $value := .Values.environment }}
+            - name: {{ $key | quote }}
+              value: {{ $value | quote }}
+            {{- end }}
           {{- range $key, $value := .Values.args }}
           args:
             - --{{ $key }}={{ $value }}

--- a/charts/registry-creds/values.yaml
+++ b/charts/registry-creds/values.yaml
@@ -67,6 +67,10 @@ acr:
   # acr.password is the client password used to access azure container registry. Only applicable if acr.existingSecretName is empty
   password: ""
 
+# environment environment variables to add to the container, can be used for HTTP_PROXY settings
+# default: null
+environment: {}
+
 rbac:
   # rbac.enabled enables the usage of RBAC for registry-creds
   enabled: true


### PR DESCRIPTION
When running in an enterprise environment, we need to be able to provide http_proxy settings.