### PR TITLE
Add local path provisioner sync workflow

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v4.3.0
         with:
-          version: v3.6.3
+          version: v3.17.1
 
       # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
       # yamllint (https://github.com/adrienverge/yamllint) which require Python
@@ -24,7 +24,7 @@ jobs:
           python-version: 3.8
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.1.0
+        uses: helm/chart-testing-action@v2.7.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -38,7 +38,7 @@ jobs:
         run: ct lint --config ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1.12.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -20,16 +20,12 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v4.3.0
         with:
-          version: v3.4.1
-
-      - name: Add dependency chart repos
-        run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
+          version: v3.17.1
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.1.0
+        uses: helm/chart-releaser-action@v1.7.0
         with:
           charts_dir: charts
           config: cr.yaml

--- a/.github/workflows/update-local-path-provisioner.yaml
+++ b/.github/workflows/update-local-path-provisioner.yaml
@@ -1,0 +1,69 @@
+name: Sync Local Path Provisioner Chart
+
+on:
+  schedule:
+    # Runs once a week, every Monday at 00:00 UTC
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+jobs:
+  sync-and-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Checkout the upstream repository
+        uses: actions/checkout@v4
+        with:
+          repository: rancher/local-path-provisioner
+          ref: master
+          path: upstream
+
+      - name: Extract upstream version
+        id: version-extract
+        run: |          
+          UPSTREAM_VERSION=$(cat upstream/deploy/chart/local-path-provisioner/Chart.yaml | grep 'version:' | awk '{print $2}')
+          echo "Upstream version: $UPSTREAM_VERSION"
+          echo "$UPSTREAM_VERSION=$UPSTREAM_VERSION" >> $GITHUB_ENV
+
+      - name: Check if the checked out version is different from current one
+        id: version-check
+        run: |          
+          if [ -f "./charts/local-path-provisioner/Chart.yaml" ]; then            
+            CURRENT_VERSION=$(cat charts/local-path-provisioner/Chart.yaml | grep 'version:' | awk '{print $2}')
+            echo "Current version: $CURRENT_VERSION"
+          
+            if [ "$CURRENT_VERSION" != "${{ env.UPSTREAM_VERSION }}" ]; then
+              echo "version_changed=true" >> $GITHUB_ENV
+            else
+              echo "version_changed=false" >> $GITHUB_ENV
+            fi
+          else
+            # If Chart.yaml does not exist, treat it as a new version
+            echo "version_changed=true" >> $GITHUB_ENV
+            echo "Current version: None"
+          fi
+
+      - name: Copy Helm Chart to my repo
+        if: env.version_changed == 'true'
+        run: |
+          mkdir -p ./charts/local-path-provisioner
+          # Copy the chart from upstream repo to the charts folder in the current repo
+          cp -r upstream/deploy/chart/local-path-provisioner/* ./charts/local-path-provisioner/
+
+      - name: Create Pull Request
+        if: env.version_changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          title: "Sync local-path-provisioner Helm chart to version ${{ env.UPSTREAM_VERSION }}"
+          body: "This PR syncs the latest version of the local-path-provisioner chart from the upstream repository to version ${{ env.UPSTREAM_VERSION }}."
+          branch: local-path-provisioner
+          delete-branch: true
+          commit-message: "Sync local-path-provisioner Helm chart to version ${{ env.UPSTREAM_VERSION }}"
+          labels: |
+            automated pr
+          add-paths: |
+            charts/local-path-provisioner/**

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+### Helm template
+# Chart dependencies
+**/charts/*.tgz
+
+# Used in CI to check out remotes
+upstream/**

--- a/ct.yaml
+++ b/ct.yaml
@@ -2,4 +2,5 @@
 remote: origin
 chart-dirs:
   - charts
+target-branch: master
 helm-extra-args: --timeout 600s

--- a/ct.yaml
+++ b/ct.yaml
@@ -2,6 +2,4 @@
 remote: origin
 chart-dirs:
   - charts
-chart-repos:
-  - bitnami=https://charts.bitnami.com/bitnami
 helm-extra-args: --timeout 600s


### PR DESCRIPTION
This PR adds a new workflow to generate[ local-path-provisioner Helm chart](https://github.com/rancher/local-path-provisioner/tree/master/deploy/chart/local-path-provisioner). 

Basically:
  * Checks out the upstream repo
  * Compares current and upstream chart versions
  * If the upstream changes, create a PR with the updated chart

(I haven't tested the workflow, for sure some fixing will be needed)

Additionally, I have bumped actions versions (happy path, so probably some fixing will also be needed since I'm bumping majors) and removed bitnami charts dependency (can't remember why they are there, might need to add them back)